### PR TITLE
Include url in list_threads and search_threads summaries

### DIFF
--- a/src/edstem_mcp/_helpers.py
+++ b/src/edstem_mcp/_helpers.py
@@ -127,6 +127,10 @@ def _summarise_threads(threads: list[dict], course_id: int) -> list[dict]:
             if t.get(k):
                 summary[k] = True
         summary["user"] = t.get("user", {}).get("name", "")
+        # Ed URLs use the global thread id, not the course-local number; include
+        # a pre-built url so callers don't mis-construct links from `number`.
+        if "id" in summary:
+            summary["url"] = _thread_url(course_id, summary["id"])
         result.append(summary)
     return result
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -80,8 +80,9 @@ def test_summarise_threads_keeps_only_summary_keys():
     assert "editor_id" not in result[0]
 
 
-def test_summarise_threads_no_url():
-    """URLs are reconstructible from id + course_id — don't waste tokens."""
+def test_summarise_threads_includes_url():
+    """URL is pre-built from the global thread id so callers don't mis-construct
+    links from `number` (which doesn't resolve on Ed)."""
     threads = [{
         "id": 123, "number": 42, "type": "post", "title": "Hello",
         "category": "General", "subcategory": "",
@@ -90,9 +91,9 @@ def test_summarise_threads_no_url():
         "reply_count": 0, "vote_count": 0, "view_count": 0, "unresolved_count": 0,
         "user": {"name": "Alice"},
     }]
-    result = _summarise_threads(threads, course_id=1)
-    assert "url" not in result[0]
-    # But id and number are still present for the LLM to reconstruct if needed
+    result = _summarise_threads(threads, course_id=77)
+    assert result[0]["url"].endswith("/courses/77/discussion/123")
+    assert "/discussion/42" not in result[0]["url"]
     assert result[0]["id"] == 123
     assert result[0]["number"] == 42
 


### PR DESCRIPTION
## Summary

- `_summarise_threads` now attaches a pre-built `url` to each thread summary, computed via `_thread_url(course_id, t["id"])`.
- Brings `list_threads` and `search_threads` in line with detail responses (`get_thread`, `get_course_thread`) and `search_index`, which already include `url`.

## Why

Summaries expose both `id` (global thread ID) and `number` (course-local #N). Ed's canonical URL format uses `id`, so `/discussion/<number>` loads a blank page — only `/discussion/<id>` resolves. Without a pre-built `url`, callers (LLMs in particular) regularly picked the wrong identifier and produced dead links.

Follow-up to #14, which originally called for `url` on both summary and detail responses but only landed for detail. Closes #40.

## Test plan

- [x] `uv run pytest -x -q` — 107 passed
- [x] Updated `test_summarise_threads_no_url` → `test_summarise_threads_includes_url`, asserting the URL uses `id` (not `number`)
- [ ] Verify a live `list_threads` call returns summaries with a usable `url` field